### PR TITLE
Ilkka/region defnition metadata

### DIFF
--- a/generated-docs/classes/ImageRegion.md
+++ b/generated-docs/classes/ImageRegion.md
@@ -20,6 +20,8 @@
 - [height](ImageRegion.md#height)
 - [radius](ImageRegion.md#radius)
 - [vertices](ImageRegion.md#vertices)
+- [idcRegionDefinitionId](ImageRegion.md#idcregiondefinitionid)
+- [idcRegionDefinitionName](ImageRegion.md#idcregiondefinitionname)
 
 ### Methods
 
@@ -198,6 +200,30 @@ Vertices/corners of a `polygon` region.
 #### Defined in
 
 [ImageRegion.ts:114](https://github.com/Frameright/image-display-control-metadata-parser/blob/main/src/ImageRegion.ts#L114)
+
+___
+
+### idcRegionDefinitionId
+
+• `Optional` **idcRegionDefinitionId**: `string`
+
+Identifier for the region definition.
+
+#### Defined in
+
+[ImageRegion.ts:119](https://github.com/Frameright/image-display-control-metadata-parser/blob/main/src/ImageRegion.ts#L119)
+
+___
+
+### idcRegionDefinitionName
+
+• `Optional` **idcRegionDefinitionName**: `string`
+
+Name for the region definition.
+
+#### Defined in
+
+[ImageRegion.ts:124](https://github.com/Frameright/image-display-control-metadata-parser/blob/main/src/ImageRegion.ts#L124)
 
 ## Methods
 

--- a/generated-docs/classes/Parser.md
+++ b/generated-docs/classes/Parser.md
@@ -22,13 +22,17 @@ https://iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#image-region
 
 ### constructor
 
-• **new Parser**(`buffer`)
+• **new Parser**(`buffer`): [`Parser`](Parser.md)
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `buffer` | `Buffer` | The image file content. |
+
+#### Returns
+
+[`Parser`](Parser.md)
 
 #### Defined in
 
@@ -86,13 +90,13 @@ ___
 
 Returns the size of the image in pixels.
 
-**`Note`**
-
-Caches the result in `this._size` for future calls.
-
 #### Returns
 
 [`Size`](../interfaces/Size.md)
+
+**`Note`**
+
+Caches the result in `this._size` for future calls.
 
 #### Defined in
 

--- a/src/ImageRegion.ts
+++ b/src/ImageRegion.ts
@@ -114,6 +114,16 @@ export class ImageRegion {
   public vertices?: Vertex[];
 
   /**
+   * Identifier for the region definition.
+   */
+  public idcRegionDefinitionId?: string;
+
+  /**
+   * Name for the region definition.
+   */
+  public idcRegionDefinitionName?: string;
+
+  /**
    * See https://cv.iptc.org/newscodes/imageregionrole/
    */
   private static readonly _CROP_XML_ROLES = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,10 +302,27 @@ export class Parser {
       }
     }
 
+    if ('RegionDefinitionId' in region) {
+      const idcRegionDefinitionId = (
+        region['RegionDefinitionId'] as ExifReader.XmpTag
+      ).value;
+      if (typeof idcRegionDefinitionId === 'string') {
+        result.idcRegionDefinitionId = idcRegionDefinitionId;
+      }
+    }
+
+    if ('RegionName' in region) {
+      const idcRegionDefinitionName = (
+        region['RegionName'] as ExifReader.XmpTag
+      ).value;
+      if (typeof idcRegionDefinitionName === 'string') {
+        result.idcRegionDefinitionName = idcRegionDefinitionName;
+      }
+    }
+
     const size = this.getSize();
     result.imageWidth = size.width;
     result.imageHeight = size.height;
-
     return result;
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@ import { Parser } from '../src';
 import { promises as fs } from 'fs';
 
 describe('Parser', () => {
-  it('can get all IDC metadata', async () => {
+  it('can get all IPTC region metadata', async () => {
     const buffer = await fs.readFile(
       'test/fixtures/thirdparty/IPTC-PhotometadataRef-Std2021.1.jpg'
     );
@@ -82,6 +82,58 @@ describe('Parser', () => {
             y: 0.863,
           },
         ],
+      },
+    ]);
+  });
+
+  it('can get all IDC metadata, including Frameright region definition data if it exists', async () => {
+    const buffer = await fs.readFile('test/fixtures/thirdparty/skater.jpg');
+    const parser = new Parser(buffer);
+    expect(parser.getIdcMetadata('any', 'any', false)).toEqual([
+      {
+        id: 'crop-e5cb8e64-b304-45fa-b56f-11fad65dac2b',
+        shape: 'rectangle',
+        roles: ['http://cv.iptc.org/newscodes/imageregionrole/cropping'],
+        unit: 'relative',
+        names: [],
+        imageWidth: 1500,
+        imageHeight: 1000,
+        x: 0.414,
+        y: 0.273,
+        width: 0.156,
+        height: 0.234,
+        idcRegionDefinitionId: 'crop-4875596e-49ca-3ba4-5965-6ba0850738ac',
+        idcRegionDefinitionName: '1:1 Square (Common sizes)',
+      },
+      {
+        id: 'crop-e93caf0a-227b-44c4-a7e6-d9b949f76163',
+        shape: 'rectangle',
+        roles: ['http://cv.iptc.org/newscodes/imageregionrole/cropping'],
+        unit: 'relative',
+        names: [],
+        imageWidth: 1500,
+        imageHeight: 1000,
+        x: 0.416,
+        y: 0.232,
+        width: 0.584,
+        height: 0.329,
+        idcRegionDefinitionId: 'crop-b4fd5a85-6671-a9b2-198e-e5276511c32d',
+        idcRegionDefinitionName: 'Horizontal banner',
+      },
+      {
+        id: 'crop-e7c9cd32-8c28-4a4a-8be9-b6de3bded589',
+        shape: 'rectangle',
+        roles: ['http://cv.iptc.org/newscodes/imageregionrole/cropping'],
+        unit: 'relative',
+        names: [],
+        imageWidth: 1500,
+        imageHeight: 1000,
+        x: 0.4066666666666667,
+        y: 0.199,
+        width: 0.2,
+        height: 0.801,
+        idcRegionDefinitionId: 'crop-0e4dc159-07e2-2662-9269-16a3c9b97787',
+        idcRegionDefinitionName: 'Tall portrait',
       },
     ]);
   });
@@ -169,6 +221,8 @@ describe('Parser', () => {
         y: 0.273,
         width: 0.156,
         height: 0.234,
+        idcRegionDefinitionId: 'crop-4875596e-49ca-3ba4-5965-6ba0850738ac',
+        idcRegionDefinitionName: '1:1 Square (Common sizes)',
       },
       {
         id: 'crop-e93caf0a-227b-44c4-a7e6-d9b949f76163',
@@ -182,6 +236,8 @@ describe('Parser', () => {
         y: 0.232,
         width: 0.584,
         height: 0.329,
+        idcRegionDefinitionId: 'crop-b4fd5a85-6671-a9b2-198e-e5276511c32d',
+        idcRegionDefinitionName: 'Horizontal banner',
       },
       {
         id: 'crop-e7c9cd32-8c28-4a4a-8be9-b6de3bded589',
@@ -195,6 +251,8 @@ describe('Parser', () => {
         y: 0.199,
         width: 0.2,
         height: 0.801,
+        idcRegionDefinitionId: 'crop-0e4dc159-07e2-2662-9269-16a3c9b97787',
+        idcRegionDefinitionName: 'Tall portrait',
       },
     ]);
   });


### PR DESCRIPTION
Small update to the metadata parser to support the region definition name and id metadata coming from Frameright.app.

I updated the types and tests, and all tests are passing. Also ran manual tests to ensure that the data was returned correctly.